### PR TITLE
chore: remove title from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: Brief description of the bug
+title: ''
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: Brief description of the feature
+title: ''
 labels: enhancement
 assignees: ''
 


### PR DESCRIPTION
Refs: closes #6 

## Summary

Remove the placeholder for titles in the issue templates.